### PR TITLE
Fix for crash when sending a crash report

### DIFF
--- a/Classes/CrashReporting/BITCrashReportManager.m
+++ b/Classes/CrashReporting/BITCrashReportManager.m
@@ -126,8 +126,8 @@
     _analyzerStarted = NO;
     _didCrashInLastSession = NO;
     
-    _userName = @"";
-    _userEmail = @"";
+    self.userName = @"";
+    self.userEmail = @"";
     
     _crashFiles = [[NSMutableArray alloc] init];
     _crashesDir = nil;
@@ -198,9 +198,9 @@
 
   [_fileManager release]; _fileManager = nil;
   
-  [_userName release]; _userName = nil;
-  [_userEmail release]; _userEmail = nil;
-  
+  self.userName = nil;
+  self.userEmail = nil;
+
   [_crashFiles release]; _crashFiles = nil;
   [_crashesDir release]; _crashesDir = nil;
   [_settingsFile release]; _settingsFile = nil;
@@ -219,8 +219,8 @@
   NSString *error = nil;
 
   NSMutableDictionary *rootObj = [NSMutableDictionary dictionaryWithCapacity:4];
-  [rootObj setObject:_userName forKey:kHockeySDKUserName];
-  [rootObj setObject:_userEmail forKey:kHockeySDKUserEmail];
+  [rootObj setObject:self.userName forKey:kHockeySDKUserName];
+  [rootObj setObject:self.userEmail forKey:kHockeySDKUserEmail];
   if (_approvedCrashReports && [_approvedCrashReports count] > 0)
     [rootObj setObject:_approvedCrashReports forKey:kHockeySDKApprovedCrashReports];
   [rootObj setObject:[NSNumber numberWithBool:_analyzerStarted] forKey:kHockeySDKAnalyzerStarted];
@@ -253,8 +253,8 @@
     if ([rootObj objectForKey:kHockeySDKApprovedCrashReports])
       [_approvedCrashReports setDictionary:[rootObj objectForKey:kHockeySDKApprovedCrashReports]];
     _analyzerStarted = [(NSNumber *)[rootObj objectForKey:kHockeySDKAnalyzerStarted] boolValue];
-    _userName = [rootObj objectForKey:kHockeySDKUserName] ?: @"";
-    _userEmail = [rootObj objectForKey:kHockeySDKUserEmail] ?: @"";
+    self.userName = [rootObj objectForKey:kHockeySDKUserName] ?: @"";
+    self.userEmail = [rootObj objectForKey:kHockeySDKUserEmail] ?: @"";
   } else {
     HockeySDKLog(@"ERROR: Reading settings. %@", error);
   }
@@ -462,8 +462,8 @@
                                                    applicationName:[self applicationName]
                                                     askUserDetails:_askUserDetails];
         
-        [_crashReportUI setUserName:_userName];
-        [_crashReportUI setUserEmail:_userEmail];
+        [_crashReportUI setUserName:self.userName];
+        [_crashReportUI setUserEmail:self.userEmail];
         
         [_crashReportUI askCrashReportDetails];
       } else {
@@ -499,8 +499,8 @@
   if (!crashDescription) crashDescription = @"";
   [metaDict setObject:crashDescription forKey:@"description"];
   
-  [metaDict setObject:_userName forKey:@"username"];
-  [metaDict setObject:_userEmail forKey:@"useremail"];
+  [metaDict setObject:self.userName forKey:@"username"];
+  [metaDict setObject:self.userEmail forKey:@"useremail"];
   
   if (_delegate != nil && [_delegate respondsToSelector:@selector(crashReportApplicationLog)]) {
     log = [self.delegate crashReportApplicationLog] ?: @"";

--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -59,9 +59,9 @@ const CGFloat kDetailsHeight = 285;
     _crashLogContent = [crashReport copy];
     _logContent = [logContent copy];
     _companyName = [companyName copy];
-    _applicationName = applicationName;
-    _userName = @"";
-    _userEmail = @"";
+    _applicationName = [applicationName copy];
+    self.userName = @"";
+    self.userEmail = @"";
     [self setShowComments: YES];
     [self setShowDetails: NO];
     [self setShowUserDetails:askUserDetails];
@@ -197,13 +197,13 @@ const CGFloat kDetailsHeight = 285;
   [[self window] setTitle:[NSString stringWithFormat:HockeySDKLocalizedString(@"WindowTitle", @""), _applicationName]];
   
   [[nameTextFieldTitle cell] setTitle:HockeySDKLocalizedString(@"NameTextTitle", @"")];
-  [[nameTextField cell] setTitle:_userName];
+  [[nameTextField cell] setTitle:self.userName];
   if ([[nameTextField cell] respondsToSelector:@selector(setUsesSingleLineMode:)]) {
     [[nameTextField cell] setUsesSingleLineMode:YES];
   }
   
   [[emailTextFieldTitle cell] setTitle:HockeySDKLocalizedString(@"EmailTextTitle", @"")];
-  [[emailTextField cell] setTitle:_userEmail];
+  [[emailTextField cell] setTitle:self.userEmail];
   if ([[emailTextField cell] respondsToSelector:@selector(setUsesSingleLineMode:)]) {
     [[emailTextField cell] setUsesSingleLineMode:YES];
   }
@@ -266,8 +266,8 @@ const CGFloat kDetailsHeight = 285;
   [_logContent release]; _logContent = nil;
   [_applicationName release]; _applicationName = nil;
   [_companyName release]; _companyName = nil;
-  [_userName release]; _userName = nil;
-  [_userEmail release]; _userEmail = nil;
+  self.userName = nil;
+  self.userEmail = nil;
   
   _crashReportManager = nil;
   


### PR DESCRIPTION
if the manager was initialized in a different autorelease pool than startManager was called the old memory management code crashed. By providing a dangling pointer as title to a textfield in the UI.
