### PR TITLE
pass the crashFile name, not the crashReport contents

### DIFF
--- a/Classes/CrashReporting/BITCrashReportManager.m
+++ b/Classes/CrashReporting/BITCrashReportManager.m
@@ -467,7 +467,7 @@
         
         [_crashReportUI askCrashReportDetails];
       } else {
-        [self sendReportWithCrash:crashReport crashDescription:nil];
+        [self sendReportWithCrash:crashFile crashDescription:nil];
       }
     } else {
       if (![self hasNonApprovedCrashReports]) {


### PR DESCRIPTION
`startManager` was mistakenly passing the contents of the crash report, stored in `crashReport` to `sendReportWithCrash` which takes the filename (for constructing the .meta filename).
