### PR TITLE
CrashReportingUI - Text in details text view can now be selected

### DIFF
--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -98,7 +98,6 @@ const CGFloat kDetailsHeight = 285;
 
 - (void)awakeFromNib {
   [crashLogTextView setEditable:NO];
-  [crashLogTextView setSelectable:NO];
   if ([crashLogTextView respondsToSelector:@selector(setAutomaticSpellingCorrectionEnabled:)]) {
     [crashLogTextView setAutomaticSpellingCorrectionEnabled:NO];
   }


### PR DESCRIPTION
I'm currently experiencing an issue with at least one user where their crash reports are not showing up after they send them.  I asked the user to copy and paste the text from the details text view that shows up when you click "Show Details".  Unfortunately, this text view doesn't allow you to select its text.

Removed the line in the awakeFromNib function specifically disabling selection for the NSTextView in question.

This gives the user at least some reasonable way of getting the crash log details to me.
