### PR TITLE
Fix broken, crash-causing French translation.

### DIFF
--- a/Resources/fr.lproj/HockeySDK.strings
+++ b/Resources/fr.lproj/HockeySDK.strings
@@ -11,7 +11,7 @@
 "WindowTitle" = "Rapport de problèmes pour %@";
 
 /* Introduction text, with app name placeholder first and company placeholder second */
-"IntroductionText" = "%@ s’est arrêté automatiquement lors de sa dernière utilisation. Souhaitez-vous envoyer un rapport de plantage à %@?";
+"IntroductionText" = "%@ s’est arrêté automatiquement lors de sa dernière utilisation. Souhaitez-vous envoyer un rapport de plantage aux developperus de l’application?";
 
 /* Name Text Title */
 "NameTextTitle" = "Nom";


### PR DESCRIPTION
The translation of IntroductionText had two occurrences of %@ in it, causing
stringWithFormat: to crash in askCrashReportDetails.  Needless to say, crashing
on application startup when trying to report a crash and preventing the
application from ever successfully launching again is less than ideal.

This could be fixed by using %1$@ for the second occurrence, but repeating the
name multiple times is not ideal, so this commit replaces it with "to the
application's developers" instead, as suggested by a native French speaker.
