### PR TITLE
Update LastUgpradeCheck in HockeySDK project.

### DIFF
--- a/Support/HockeySDK.xcodeproj/project.pbxproj
+++ b/Support/HockeySDK.xcodeproj/project.pbxproj
@@ -499,7 +499,7 @@
 		1EF09D821523574200067A5C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0510;
 			};
 			buildConfigurationList = 1EF09D851523574200067A5C /* Build configuration list for PBXProject "HockeySDK" */;
 			compatibilityVersion = "Xcode 3.2";


### PR DESCRIPTION
Schemes were updated in 85f2f66, but the same change in project.pbxproj
was forgotten.  Fix this and silence the upgrade warning.
