### PR TITLE
Remove remnants of modal window crash UI code

### DIFF
--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -69,9 +69,7 @@ const CGFloat kDetailsHeight = 285;
   IBOutlet NSButton *hideButton;
   IBOutlet NSButton *cancelButton;
   IBOutlet NSButton *submitButton;
-  
-  NSMenu          *_mainAppMenu;
-  
+
   BITCrashManager *_crashManager;
   
   NSString *_applicationName;
@@ -90,7 +88,6 @@ const CGFloat kDetailsHeight = 285;
   self = [super initWithWindowNibName: @"BITCrashReportUI"];
   
   if ( self != nil) {
-    _mainAppMenu = [NSApp mainMenu];
     _crashManager = crashManager;
     _crashLogContent = [crashReport copy];
     _logContent = [logContent copy];
@@ -141,8 +138,6 @@ const CGFloat kDetailsHeight = 285;
 
 - (void)endCrashReporter {
   [self close];
-  [NSApp stopModal];
-  [NSApp setMainMenu:_mainAppMenu];
 }
 
 


### PR DESCRIPTION
Remove forgotten remnants of code from when HockeySDK used a modal
window for reporting crash reports. Now that it no longer does that,
there's no reason to reset the main app menu (the operation is usually
noop, which is why it went unnoticed; but can break code that does
something unusual).

Don't call [NSApp stopModal] either, because there's no corresponding
startModalForWindow: anymore.