### PR TITLE
Add ability to submit crash reports modally

### DIFF
--- a/Classes/CrashReporting/BITCrashManager.h
+++ b/Classes/CrashReporting/BITCrashManager.h
@@ -190,6 +190,15 @@ typedef NS_ENUM(NSUInteger, BITCrashManagerUserInput) {
  */
 @property (nonatomic, assign, getter=isAutoSubmitCrashReport) BOOL autoSubmitCrashReport;
 
+
+/**
+ *  Defines if the crash report UI should be shown modally
+ *
+ *  Default: _NO_
+ */
+@property (nonatomic, assign) BOOL submitModally;
+
+
 /**
  * Set the callbacks that will be executed prior to program termination after a crash has occurred
  *

--- a/Classes/CrashReporting/BITCrashManager.m
+++ b/Classes/CrashReporting/BITCrashManager.m
@@ -128,7 +128,8 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
     
     _crashFiles = [[NSMutableArray alloc] init];
     _crashesDir = nil;
-    
+
+    _submitModally = NO;
     self.delegate = nil;
     
     NSString *testValue = nil;
@@ -730,6 +731,9 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
             [_crashReportUI askCrashReportDetails];
             [_crashReportUI showWindow:self];
             [_crashReportUI.window makeKeyAndOrderFront:self];
+            if (self.submitModally) {
+              [_crashReportUI runModally];
+            }
           } else {
             [self sendNextCrashReport];
           }

--- a/Classes/CrashReporting/BITCrashReportUI.h
+++ b/Classes/CrashReporting/BITCrashReportUI.h
@@ -49,6 +49,8 @@
                 applicationName:(NSString *)applicationName
                  askUserDetails:(BOOL)askUserDetails;
 
+- (void)runModally;
+
 - (void)askCrashReportDetails;
 
 - (IBAction)cancelReport:(id)sender;

--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -80,6 +80,7 @@ const CGFloat kDetailsHeight = 285;
   BOOL _showUserDetails;
   BOOL _showComments;
   BOOL _showDetails;
+  BOOL _runModally;
 }
 
 
@@ -98,6 +99,7 @@ const CGFloat kDetailsHeight = 285;
     _showDetails = NO;
     _showUserDetails = askUserDetails;
     _nibDidLoadSuccessfully = NO;
+    _runModally = NO;
 
     NSRect windowFrame = [[self window] frame];
     windowFrame.size = NSMakeSize(windowFrame.size.width, windowFrame.size.height - kDetailsHeight);
@@ -129,6 +131,12 @@ const CGFloat kDetailsHeight = 285;
 }
 
 
+- (void)runModally {
+  _runModally = YES;
+  [NSApp runModalForWindow:[self window]];
+}
+
+
 - (void)awakeFromNib {
   _nibDidLoadSuccessfully = YES;
   [crashLogTextView setEditable:NO];
@@ -140,6 +148,9 @@ const CGFloat kDetailsHeight = 285;
 
 - (void)endCrashReporter {
   [self close];
+  if (_runModally) {
+    [NSApp stopModal];
+  }
 }
 
 


### PR DESCRIPTION
Restore functionality from pre-3.0 HockeySDK: submitting crash reports from a modal window. The default behavior remains unchanged, but user code can now explicitly opt into pre-3.0 modal behavior by setting the `BITCrashManager.submitModally` property.

I realize this may be something you’d rather not have and if you prefer not to merge (even in modified form), that’s fine by me. I am using this modification in my app, because I deal with code that uses wxWidgets and so creates the main window after `applicationDidFinishLaunching:`. This results in HockeySDK UI not being shown on top and worse, fixing it well would be a convoluted mess at best. Running the reporting UI modally seems to be the lesser evil.

After all, you mention this situation in 3.0’s release notes as a potential compatibility problem, so perhaps this PR’s `submitModally` would be useful to others too: it makes upgrading to 3.0 in situations like mine significantly less painful. 
