### PR TITLE
Fixed crash reporter window positioning

### DIFF
--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -101,11 +101,11 @@ const CGFloat kDetailsHeight = 285;
 
     NSRect windowFrame = [[self window] frame];
     windowFrame.size = NSMakeSize(windowFrame.size.width, windowFrame.size.height - kDetailsHeight);
-    windowFrame.origin.y -= kDetailsHeight;
+    windowFrame.origin.y += kDetailsHeight / 2;
     
     if (!askUserDetails) {
       windowFrame.size = NSMakeSize(windowFrame.size.width, windowFrame.size.height - kUserHeight);
-      windowFrame.origin.y -= kUserHeight;
+      windowFrame.origin.y += kUserHeight / 2;
       
       NSRect frame = commentsTextFieldTitle.frame;
       frame.origin.y += kUserHeight;

--- a/Classes/CrashReporting/BITCrashReportUI.xib
+++ b/Classes/CrashReporting/BITCrashReportUI.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="14C2507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment version="1060" identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
@@ -29,7 +29,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Crash Reporter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="361" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <windowPositionMask key="initialPositionMask" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="602" y="592" width="571" height="647"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
             <value key="minSize" type="size" width="213" height="107"/>


### PR DESCRIPTION
The crash reporter window was appearing at the bottom of the screen and off to the left. This change centers the window horizontally, and correctly adjusts the y origin for the hidden sections.