### PR TITLE
Ensure crash report window gets centered when shown.

### DIFF
--- a/Classes/CrashReporting/BITCrashReportUI.m
+++ b/Classes/CrashReporting/BITCrashReportUI.m
@@ -123,9 +123,10 @@ const CGFloat kDetailsHeight = 285;
     [[self window] setFrame: windowFrame
                     display: YES
                     animate: NO];
+    [[self window] center];
     
   }
-  return self;  
+  return self;
 }
 
 


### PR DESCRIPTION
The report window wasn't always centered when being shown.