### PR TITLE
Silence a non-null warning on Xcode 7.

### DIFF
--- a/Classes/Feedback/BITFeedbackMessageCellView.m
+++ b/Classes/Feedback/BITFeedbackMessageCellView.m
@@ -195,7 +195,7 @@
       
       BITActivityIndicatorButton *imageButton = [[BITActivityIndicatorButton alloc] initWithFrame:frame];
       
-      imageButton.title = nil;
+      imageButton.title = @"";
       imageButton.imagePosition = NSImageOnly;
       [imageButton setBordered:NO];
       


### PR DESCRIPTION
Making a nonnull annotation happy.