### PR TITLE
CoreFoundation fixes in feedback attchments

### DIFF
--- a/Classes/Feedback/BITFeedbackMessageAttachment.m
+++ b/Classes/Feedback/BITFeedbackMessageAttachment.m
@@ -216,14 +216,17 @@
   // File extension that suits the Content type.
   
   CFStringRef mimeType = (__bridge CFStringRef)self.contentType;
-  CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType, NULL);
-  CFStringRef extension = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassFilenameExtension);
-  if (extension) {
-    _tempFilename = [_tempFilename stringByAppendingPathExtension:(__bridge NSString *)(extension)];
-    CFRelease(extension);
+  if (mimeType) {
+    CFStringRef uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassMIMEType, mimeType, NULL);
+    CFStringRef extension = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassFilenameExtension);
+    if (extension) {
+      _tempFilename = [_tempFilename stringByAppendingPathExtension:(__bridge NSString *)(extension)];
+      CFRelease(extension);
+    }
+    if (uti) {
+      CFRelease(uti);
+    }
   }
-  
-  CFRelease(uti);
   
   return _tempFilename;
 }

--- a/Classes/Feedback/BITFeedbackWindowController.m
+++ b/Classes/Feedback/BITFeedbackWindowController.m
@@ -512,7 +512,7 @@ NSString * const BITFeedbackMessageDateValueTransformerName = @"BITFeedbackMessa
     if (UTI) {
       CFStringRef mimeType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
       CFRelease(UTI);
-      mimeTypeString = (__bridge NSString *)mimeType;
+      mimeTypeString = (__bridge_transfer NSString *)mimeType;
     }
     
     BITFeedbackMessageAttachment *attachment = [BITFeedbackMessageAttachment attachmentWithData:data contentType:mimeTypeString];

--- a/Classes/Feedback/BITFeedbackWindowController.m
+++ b/Classes/Feedback/BITFeedbackWindowController.m
@@ -507,9 +507,13 @@ NSString * const BITFeedbackMessageDateValueTransformerName = @"BITFeedbackMessa
   if (!error && data) {
     CFStringRef fileExtension = (__bridge CFStringRef)[filename pathExtension];
     CFStringRef UTI = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, fileExtension, NULL);
-    CFStringRef mimeType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
-    CFRelease(UTI);
-    NSString *mimeTypeString = (__bridge NSString *)mimeType;
+
+    NSString *mimeTypeString = nil;
+    if (UTI) {
+      CFStringRef mimeType = UTTypeCopyPreferredTagWithClass(UTI, kUTTagClassMIMEType);
+      CFRelease(UTI);
+      mimeTypeString = (__bridge NSString *)mimeType;
+    }
     
     BITFeedbackMessageAttachment *attachment = [BITFeedbackMessageAttachment attachmentWithData:data contentType:mimeTypeString];
     attachment.originalFilename = filename;


### PR DESCRIPTION
Some fixes in CoreFoundation handling of feedback attachments.

To demonstrate, try to attach a *.log file to a feedback.