### PR TITLE
Programmatically attach files to feedback

### DIFF
--- a/Classes/Feedback/BITFeedbackManager.h
+++ b/Classes/Feedback/BITFeedbackManager.h
@@ -166,11 +166,16 @@ typedef NS_ENUM(NSInteger, BITFeedbackUserDataElement) {
 - (void)showFeedbackWindow;
 
 /**
- Present the modal feedback list user interface and attach the given attachments.
- 
+ Present the modal feedback compose message user interface with the items given.
+
+ All NSString-Content in the array will be concatenated and result in the message,
+ while all UIImage and NSData-instances will be turned into attachments.
+
  Attachments is an array of NSString paths. Please make sure the paths are readable, especially if
- your app is sandboxed.
+ All BITMessageAttachment-instances will be used as is.
+
+ @param items an NSArray with objects that should be attached
  */
-- (void)showFeedbackWindowWithAttachments:(NSArray<NSString*>*)attachments;
+- (void)showFeedbackComposeViewWithPreparedItems:(NSArray *)items;
 
 @end

--- a/Classes/Feedback/BITFeedbackManager.h
+++ b/Classes/Feedback/BITFeedbackManager.h
@@ -165,5 +165,12 @@ typedef NS_ENUM(NSInteger, BITFeedbackUserDataElement) {
  */
 - (void)showFeedbackWindow;
 
+/**
+ Present the modal feedback list user interface and attach the given attachments.
+ 
+ Attachments is an array of NSString paths. Please make sure the paths are readable, especially if
+ your app is sandboxed.
+ */
+- (void)showFeedbackWindowWithAttachments:(NSArray<NSString*>*)attachments;
 
 @end

--- a/Classes/Feedback/BITFeedbackManager.m
+++ b/Classes/Feedback/BITFeedbackManager.m
@@ -139,14 +139,12 @@
   [_feedbackWindowController.window makeKeyAndOrderFront:self];
 }
 
-- (void)showFeedbackWindowWithAttachments:(NSArray<NSString*>*)attachments {
+- (void)showFeedbackComposeViewWithPreparedItems:(NSArray *)attachmentItems {
   if (!_feedbackWindowController) {
     _feedbackWindowController = [[BITFeedbackWindowController alloc] initWithManager:self];
   }
 
-  for (NSString *attachment in attachments) {
-    [_feedbackWindowController addAttachmentWithFilename:attachment];
-  }
+  [_feedbackWindowController prepareWithItems:attachmentItems];
 
   [_feedbackWindowController showWindow:self];
   [_feedbackWindowController.window makeKeyAndOrderFront:self];

--- a/Classes/Feedback/BITFeedbackManager.m
+++ b/Classes/Feedback/BITFeedbackManager.m
@@ -139,6 +139,19 @@
   [_feedbackWindowController.window makeKeyAndOrderFront:self];
 }
 
+- (void)showFeedbackWindowWithAttachments:(NSArray<NSString*>*)attachments {
+  if (!_feedbackWindowController) {
+    _feedbackWindowController = [[BITFeedbackWindowController alloc] initWithManager:self];
+  }
+
+  for (NSString *attachment in attachments) {
+    [_feedbackWindowController addAttachmentWithFilename:attachment];
+  }
+
+  [_feedbackWindowController showWindow:self];
+  [_feedbackWindowController.window makeKeyAndOrderFront:self];
+}
+
 
 #pragma mark - Manager Control
 

--- a/Classes/Feedback/BITFeedbackWindowController.h
+++ b/Classes/Feedback/BITFeedbackWindowController.h
@@ -34,6 +34,6 @@
 
 - (id)initWithManager:(BITFeedbackManager *)feedbackManager;
 
-- (void)addAttachmentWithFilename:(NSString *)filename;
+- (void)prepareWithItems:(NSArray *)items;
 
 @end

--- a/Classes/Feedback/BITFeedbackWindowController.h
+++ b/Classes/Feedback/BITFeedbackWindowController.h
@@ -34,4 +34,6 @@
 
 - (id)initWithManager:(BITFeedbackManager *)feedbackManager;
 
+- (void)addAttachmentWithFilename:(NSString *)filename;
+
 @end

--- a/Classes/Feedback/BITFeedbackWindowController.m
+++ b/Classes/Feedback/BITFeedbackWindowController.m
@@ -501,6 +501,85 @@ NSString * const BITFeedbackMessageDateValueTransformerName = @"BITFeedbackMessa
   [self togglePreviewPanel:self];
 }
 
+- (void)prepareWithItems:(NSArray *)items {
+  self.messageText = [[NSAttributedString alloc] init];
+  for (id item in items) {
+
+    if ([item isKindOfClass:[NSString class]]) {
+      NSMutableAttributedString *newString = [self.messageText mutableCopy];
+      [newString appendAttributedString:[[NSAttributedString alloc]
+                                            initWithString:item]];
+      self.messageText = newString;
+    } else if ([item isKindOfClass:[NSURL class]]) {
+      NSMutableAttributedString *newString = [self.messageText mutableCopy];
+      [newString
+          appendAttributedString:[[NSAttributedString alloc]
+                                     initWithString:[(NSURL *)item
+                                                        absoluteString]]];
+      self.messageText = newString;
+    } else if ([item isKindOfClass:[NSImage class]]) {
+      NSImage *image = item;
+
+      NSData *imageData = [image TIFFRepresentation];
+      NSBitmapImageRep *imageRep =
+          [NSBitmapImageRep imageRepWithData:imageData];
+      NSDictionary *imageProps =
+          [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:0.7]
+                                      forKey:NSImageCompressionFactor];
+      imageData = [imageRep representationUsingType:NSJPEGFileType
+                                         properties:imageProps];
+
+      BITFeedbackMessageAttachment *attachment =
+          [BITFeedbackMessageAttachment attachmentWithData:imageData
+                                               contentType:@"image/jpeg"];
+      attachment.originalFilename =
+          [NSString stringWithFormat:@"Image_%li.jpg",
+                                     (unsigned long)[self.attachments count]];
+      [self.attachments addObject:attachment];
+    } else if ([item isKindOfClass:[NSData class]]) {
+      BITFeedbackMessageAttachment *attachment = [BITFeedbackMessageAttachment
+          attachmentWithData:item
+                 contentType:@"application/octet-stream"];
+      attachment.originalFilename =
+          [NSString stringWithFormat:@"Attachment_%li.data",
+                                     (unsigned long)[self.attachments count]];
+      [self.attachments addObject:attachment];
+    } else if ([item isKindOfClass:[BITHockeyAttachment class]]) {
+      BITHockeyAttachment *sourceAttachment = (BITHockeyAttachment *)item;
+
+      if (!sourceAttachment.hockeyAttachmentData) {
+        BITHockeyLog(@"BITHockeyAttachment instance doesn't contain any data.");
+        continue;
+      }
+
+      NSString *filename =
+          [NSString stringWithFormat:@"Attachment_%li.data",
+                                     (unsigned long)[self.attachments count]];
+      if (sourceAttachment.filename) {
+        filename = sourceAttachment.filename;
+      }
+
+      BITFeedbackMessageAttachment *attachment = [BITFeedbackMessageAttachment
+          attachmentWithData:sourceAttachment.hockeyAttachmentData
+                 contentType:sourceAttachment.contentType];
+      attachment.originalFilename = filename;
+      [self.attachments addObject:attachment];
+      [self.composeAttacchmentsArrayController setContent:self.attachments];
+      [self.feedbackAttachmentsTableView
+              selectRowIndexes:[NSIndexSet
+                                   indexSetWithIndex:[self.attachments count] -
+                                                     1]
+          byExtendingSelection:NO];
+      [self.feedbackAttachmentsTableView
+          scrollRowToVisible:[self.attachments count] - 1];
+
+      [self showComposeAttachments];
+    } else {
+      BITHockeyLog(@"Unknown item type %@", item);
+    }
+  }
+}
+
 - (void)addAttachmentWithFilename:(NSString *)filename {
   NSError *error = nil;
   NSData *data = [NSData dataWithContentsOfFile:filename options:0 error:&error];


### PR DESCRIPTION
This is just a quick hack to demonstrate what I mean in #59 and get things going.

What is the best way the get the files to attach? In a delegate callback? Should the files only be attached on the first feedback?

Should the programmatically attached files show up in the UI? It could confuse the user.
