### PR TITLE
Fix an Xcode 7.3 warning because a function wasn't being dereferenced.

### DIFF
--- a/Classes/CrashReporting/BITCrashManager.m
+++ b/Classes/CrashReporting/BITCrashManager.m
@@ -99,7 +99,7 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
 
 - (instancetype)initWithCXXExceptionInfo:(const BITCrashUncaughtCXXExceptionInfo *)info {
   extern char* __cxa_demangle(const char* mangled_name, char* output_buffer, size_t* length, int* status);
-  char *demangled_name = __cxa_demangle ? __cxa_demangle(info->exception_type_name ?: "", NULL, NULL, NULL) : NULL;
+  char *demangled_name = &__cxa_demangle ? __cxa_demangle(info->exception_type_name ?: "", NULL, NULL, NULL) : NULL;
   
   if ((self = [super
                initWithName:[NSString stringWithUTF8String:demangled_name ?: info->exception_type_name ?: ""]


### PR DESCRIPTION
Silences an Xcode 7.3 warning.