### PR TITLE
Only exclude subfolder from backup

### DIFF
--- a/Classes/BITHockeyManager.m
+++ b/Classes/BITHockeyManager.m
@@ -174,6 +174,11 @@ NSString *const kBITHockeySDKURL = @"https://sdk.hockeyapp.net/";
     return;
   }
   
+  // Fix bug where Application Support directory was encluded from backup
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  NSURL *appSupportURL = [[fileManager URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject];
+  bit_fixBackupAttributeForURL(appSupportURL);
+  
   BITHockeyLog(@"INFO: Starting HockeyManager");
   _startManagerIsInvoked = YES;
   

--- a/Classes/Helper/BITHockeyHelper.h
+++ b/Classes/Helper/BITHockeyHelper.h
@@ -1,5 +1,7 @@
 #import <Foundation/Foundation.h>
 
+FOUNDATION_EXPORT NSString *const kBITExcludeApplicationSupportFromBackup;
+
 /* NSString helpers */
 NSString *bit_URLEncodedString(NSString *inputString);
 NSString *bit_URLDecodedString(NSString *inputString);
@@ -29,3 +31,6 @@ NSString *bit_deviceLanguage(void);
 NSString *bit_screenSize(void);
 NSString *bit_sdkVersion(void);
 NSString *bit_appVersion(void);
+
+/* Fix bug where Application Support was excluded from backup. */
+void bit_fixBackupAttributeForURL(NSURL *directoryURL);

--- a/Classes/Helper/BITHockeyHelper.m
+++ b/Classes/Helper/BITHockeyHelper.m
@@ -5,6 +5,8 @@
 #import <sys/sysctl.h>
 #import <AppKit/AppKit.h>
 
+NSString *const kBITExcludeApplicationSupportFromBackup = @"kBITExcludeApplicationSupportFromBackup";
+
 typedef struct {
   uint8_t       info_version;
   const char    bit_version[16];
@@ -68,6 +70,28 @@ NSComparisonResult bit_versionCompare(NSString *stringA, NSString *stringB) {
   // Done
   return result;
 }
+
+#pragma mark Exclude from backup fix
+
+void bit_fixBackupAttributeForURL(NSURL *directoryURL) {
+  
+  BOOL shouldExcludeAppSupportDirFromBackup = [[NSUserDefaults standardUserDefaults] boolForKey:kBITExcludeApplicationSupportFromBackup];
+  if (shouldExcludeAppSupportDirFromBackup) {
+    return;
+  }
+  
+  if (directoryURL) {
+    NSError *getResourceError = nil;
+    NSNumber *appSupportDirExcludedValue;
+    
+    if ([directoryURL getResourceValue:&appSupportDirExcludedValue forKey:NSURLIsExcludedFromBackupKey error:&getResourceError] && appSupportDirExcludedValue) {
+      NSError *setResourceError = nil;
+      [directoryURL setResourceValue:@NO forKey:NSURLIsExcludedFromBackupKey error:&setResourceError];
+    }
+  }
+}
+
+#pragma mark Identifiers
 
 NSString *bit_mainBundleIdentifier(void) {
   return [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"];

--- a/Classes/Telemetry/BITPersistence.m
+++ b/Classes/Telemetry/BITPersistence.m
@@ -211,15 +211,6 @@ NSUInteger const defaultFileCount = 50;
       return;
     }
     
-    //Exclude HockeySDK folder from backup
-    if (![appURL setResourceValue:@YES
-                           forKey:NSURLIsExcludedFromBackupKey
-                            error:&error]) {
-      BITHockeyLog(@"Error excluding %@ from backup %@", appURL.lastPathComponent, error.localizedDescription);
-    } else {
-      BITHockeyLog(@"Exclude %@ from backup", appURL);
-    }
-    
     // Create metadata subfolder
     NSURL *metaDataURL = [appURL URLByAppendingPathComponent:kBITMetaDataDirectory];
     if (![fileManager createDirectoryAtURL:metaDataURL withIntermediateDirectories:YES attributes:nil error:&error]) {
@@ -238,6 +229,15 @@ NSUInteger const defaultFileCount = 50;
       return;
     }
 
+    //Exclude HockeySDK folder from backup
+    if (![appURL setResourceValue:@YES
+                           forKey:NSURLIsExcludedFromBackupKey
+                            error:&error]) {
+      BITHockeyLog(@"Error excluding %@ from backup %@", appURL.lastPathComponent, error.localizedDescription);
+    } else {
+      BITHockeyLog(@"Exclude %@ from backup", appURL);
+    }
+    
     _directorySetupComplete = YES;
   }
 }
@@ -298,12 +298,12 @@ NSUInteger const defaultFileCount = 50;
 }
 
 - (NSString *)appHockeySDKDirectoryPath {
-  if(!_appHockeySDKDirectoryPath) {
+  if (!_appHockeySDKDirectoryPath) {
     NSString *appSupportPath = [[NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES) lastObject] stringByStandardizingPath];
     NSString *bundleID = bit_mainBundleIdentifier();
-    if(appSupportPath && bundleID) {
+    if (appSupportPath && bundleID) {
       NSString *hockeySDKPath = [appSupportPath stringByAppendingPathComponent:kBITHockeyDirectory];
-      _appHockeySDKDirectoryPath = [hockeySDKPath stringByAppendingString:bundleID];
+      _appHockeySDKDirectoryPath = [hockeySDKPath stringByAppendingPathComponent:bundleID];
     }
   }
   return _appHockeySDKDirectoryPath;


### PR DESCRIPTION
To repro this issue:

1. Run HockeyApp for Mac v 2.0.15 or input the following command in the terminal: `xattr -w com.apple.metadata:com_apple_backup_excludeItem true ~/Library/Application\ Support`
2. Command `xattr ~/Library/Application\ Support` should print `com.apple.metadata:com_apple_backup_excludeItem`
3. Running test app with hotfix removes attribute on `Application Support` and adds it to its `com.microsoft.HockeyApp` subfolder: `xattr ~/Library/Application\ Support/com.microsoft.HockeyApp/`
4. To explicitly ignore the fix (do not check whether attribute is set or not) add the following code before SDK initialization:
`NSUserDefaults.standardUserDefaults().setBool(true, forKey: "BITExcludeApplicationSupportFromBackup")` (swift)