### PR TITLE
Restore compatibility with OS X 10.7

### DIFF
--- a/Classes/Helper/BITHockeyHelper.m
+++ b/Classes/Helper/BITHockeyHelper.m
@@ -74,6 +74,10 @@ NSComparisonResult bit_versionCompare(NSString *stringA, NSString *stringB) {
 #pragma mark Exclude from backup fix
 
 void bit_fixBackupAttributeForURL(NSURL *directoryURL) {
+  if (&NSURLIsExcludedFromBackupKey == NULL) {
+    BITHockeyLog(@"WARNING: &NSURLIsExcludedBackupKey is NULL, returning");
+    return;
+  }
   
   BOOL shouldExcludeAppSupportDirFromBackup = [[NSUserDefaults standardUserDefaults] boolForKey:kBITExcludeApplicationSupportFromBackup];
   if (shouldExcludeAppSupportDirFromBackup) {

--- a/Classes/Telemetry/BITPersistence.m
+++ b/Classes/Telemetry/BITPersistence.m
@@ -229,13 +229,16 @@ NSUInteger const defaultFileCount = 50;
       return;
     }
 
-    //Exclude HockeySDK folder from backup
-    if (![appURL setResourceValue:@YES
-                           forKey:NSURLIsExcludedFromBackupKey
-                            error:&error]) {
-      BITHockeyLog(@"Error excluding %@ from backup %@", appURL.lastPathComponent, error.localizedDescription);
-    } else {
-      BITHockeyLog(@"Exclude %@ from backup", appURL);
+    // Make sure NSURLIsExcludedFromBackupKey is available
+    if (&NSURLIsExcludedFromBackupKey != NULL) {
+      //Exclude HockeySDK folder from backup
+      if (![appURL setResourceValue:@YES
+                             forKey:NSURLIsExcludedFromBackupKey
+                              error:&error]) {
+        BITHockeyLog(@"ERROR: Error excluding %@ from backup %@", appURL.lastPathComponent, error.localizedDescription);
+      } else {
+        BITHockeyLog(@"INFO: Exclude %@ from backup", appURL);
+      }
     }
     
     _directorySetupComplete = YES;


### PR DESCRIPTION
`NSURLIsExcludedFromBackupKey` is only available from 10.8 upwards so we need to check before using it