### PR TITLE
Fix finding latest feedback message having an ID

### DIFF
--- a/Classes/Feedback/BITFeedbackManager.m
+++ b/Classes/Feedback/BITFeedbackManager.m
@@ -427,6 +427,7 @@
   [_feedbackList enumerateObjectsUsingBlock:^(BITFeedbackMessage *objMessage, NSUInteger messagesIdx, BOOL *stop) {
     if ([[objMessage messageID] integerValue] != 0) {
       message = objMessage;
+    } else {
       *stop = YES;
     }
   }];


### PR DESCRIPTION
The previous implementation stopped at the first message having an ID instead of, as the method name suggests, getting the last item.

This change fixes the detection of knowing if there are new messages incoming from the server the user didn’t see yet and hence makes the use of the `showAlertOnIncomingMessages` actually possible.

This problem should also apply to the iOS implementation.