### PR TITLE
Add app launch timestamp to crash report

### DIFF
--- a/Classes/CrashReporting/BITCrashReportTextFormatter.m
+++ b/Classes/CrashReporting/BITCrashReportTextFormatter.m
@@ -375,7 +375,18 @@ static const char *findSEL (const char *imageName, NSString *imageUUID, uint64_t
         if (report.systemInfo.operatingSystemBuild != nil)
             osBuild = report.systemInfo.operatingSystemBuild;
         
-        [text appendFormat: @"Date/Time:       %@\n", report.systemInfo.timestamp];
+        NSLocale *enUSPOSIXLocale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
+        NSDateFormatter *rfc3339Formatter = [[NSDateFormatter alloc] init];
+        [rfc3339Formatter setLocale:enUSPOSIXLocale];
+        [rfc3339Formatter setDateFormat:@"yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'"];
+        [rfc3339Formatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+        
+        [text appendFormat: @"Date/Time:       %@\n", [rfc3339Formatter stringFromDate:report.systemInfo.timestamp]];
+        if ([report.processInfo respondsToSelector:@selector(processStartTime)]) {
+            if (report.systemInfo.timestamp && report.processInfo.processStartTime) {
+                [text appendFormat: @"Launch Time:     %@\n", [rfc3339Formatter stringFromDate:report.processInfo.processStartTime]];
+            }
+        }
         [text appendFormat: @"OS Version:      %@ %@ (%@)\n", osName, report.systemInfo.operatingSystemVersion, osBuild];
         [text appendFormat: @"Report Version:  104\n"];
     }


### PR DESCRIPTION
- Makes sure the date and time is formatted properly in each language
- Add App Launch time if available in the file provided by PLCrashReporter
