### PR TITLE
Add process id to crash details

### DIFF
--- a/Classes/CrashReporting/BITCrashDetails.h
+++ b/Classes/CrashReporting/BITCrashDetails.h
@@ -65,4 +65,9 @@
  */
 @property (nonatomic, readonly, strong) NSString *appBuild;
 
+/**
+ *  Identifier of the app process that crashed
+ */
+@property (nonatomic, readonly, assign) NSUInteger appProcessIdentifier;
+
 @end

--- a/Classes/CrashReporting/BITCrashDetails.m
+++ b/Classes/CrashReporting/BITCrashDetails.m
@@ -14,6 +14,7 @@
                                    osBuild:(NSString *)osBuild
                                 appVersion:(NSString *)appVersion
                                   appBuild:(NSString *)appBuild
+                      appProcessIdentifier:(NSUInteger)appProcessIdentifier
 {
   if ((self = [super init])) {
     _incidentIdentifier = incidentIdentifier;
@@ -27,6 +28,7 @@
     _osBuild = osBuild;
     _appVersion = appVersion;
     _appBuild = appBuild;
+    _appProcessIdentifier = appProcessIdentifier;
   }
   return self;
 }

--- a/Classes/CrashReporting/BITCrashDetailsPrivate.h
+++ b/Classes/CrashReporting/BITCrashDetailsPrivate.h
@@ -14,6 +14,7 @@
                                  osVersion:(NSString *)osVersion
                                    osBuild:(NSString *)osBuild
                                 appVersion:(NSString *)appVersion
-                                  appBuild:(NSString *)appBuild;
+                                  appBuild:(NSString *)appBuild
+                      appProcessIdentifier:(NSUInteger)appProcessIdentifier;
 
 @end

--- a/Classes/CrashReporting/BITCrashManager.m
+++ b/Classes/CrashReporting/BITCrashManager.m
@@ -601,6 +601,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
                                                                                osBuild:report.systemInfo.operatingSystemBuild
                                                                             appVersion:report.applicationInfo.applicationMarketingVersion
                                                                               appBuild:report.applicationInfo.applicationVersion
+                                                                  appProcessIdentifier:report.processInfo.processID
                                     ];
         
         // fetch and store the meta data after setting _lastSessionCrashDetails, so the property can be used in the protocol methods


### PR DESCRIPTION
Adding process id to crash details. App can use this info to attach per process id application logs if neccessary.