### PR TITLE
null check strongSelf before deref in [BITChannel startTimer]

### DIFF
--- a/Classes/Telemetry/BITChannel.m
+++ b/Classes/Telemetry/BITChannel.m
@@ -236,13 +236,14 @@ void bit_resetSafeJsonStream(char **string) {
   __weak typeof(self) weakSelf = self;
   dispatch_source_set_event_handler(self.timerSource, ^{
     typeof(self) strongSelf = weakSelf;
-    
-    if (strongSelf->_dataItemCount > 0) {
-      [strongSelf persistDataItemQueue];
-    } else {
-      strongSelf.channelBlocked = NO;
+    if (strongSelf) {
+        if (strongSelf->_dataItemCount > 0) {
+            [strongSelf persistDataItemQueue];
+        } else {
+            strongSelf.channelBlocked = NO;
+        }
+        [strongSelf invalidateTimer];
     }
-    [strongSelf invalidateTimer];
   });
   dispatch_resume(self.timerSource);
 }


### PR DESCRIPTION
Please refer to https://github.com/bitstadium/HockeySDK-Mac/issues/79
strongSelf could be null and strongSelf->_dataItemCount derefs it without checking.