### PR TITLE
Sets a higher lever to the window of CrashReporterUI

### DIFF
--- a/Classes/CrashReporting/BITCrashManager.m
+++ b/Classes/CrashReporting/BITCrashManager.m
@@ -737,6 +737,7 @@ static void uncaught_cxx_exception_handler(const BITCrashUncaughtCXXExceptionInf
           if (_crashReportUI.nibDidLoadSuccessfully) {
             [_crashReportUI askCrashReportDetails];
             [_crashReportUI showWindow:self];
+            [_crashReportUI.window setLevel:NSNormalWindowLevel+1];
             [_crashReportUI.window makeKeyAndOrderFront:self];
           } else {
             [self approveLatestCrashReport];


### PR DESCRIPTION
Sets a higher lever to the window of CrashReporterUI to make the window
always visible