### PR TITLE
Fixed feedback window for macOS Mojave Dark mode.

### DIFF
--- a/Classes/Feedback/BITFeedbackWindowController.m
+++ b/Classes/Feedback/BITFeedbackWindowController.m
@@ -111,16 +111,6 @@ static NSString * const BITFeedbackMessageDateValueTransformerName = @"BITFeedba
   appIcon = [self imageWithReducedAlpha:0.5 fromImage:appIcon];
   [self.feedbackEmptyAppImageView setImage:appIcon];
   
-  //Hard-coded colors are not compatible with Mojave Dark Mode.
-  /*
-  [self.feedbackListBackgroundView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.91 green:0.92 blue:0.93 alpha:1.0]];
-  [self.feedbackComposeBackgroundView setViewBackgroundColor:[NSColor whiteColor]];
-  [self.horizontalLine setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.79 green:0.82 blue:0.83 alpha:1.0]];
-  [self.statusBar setViewBackgroundColor:[NSColor whiteColor]];
-  [self.mainBackgroundView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.91 green:0.92 blue:0.93 alpha:1.0]];
-  [self.userDataBoxView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.88 green:0.89 blue:0.90 alpha:1.0]];
-  [self.userDataBoxView setViewBorderColor:[NSColor colorWithCalibratedRed:0.82 green:0.85 blue:0.86 alpha:1.0]];
-  */
   [self.userDataBoxView setViewBorderWidth:1.0];
   [self.feedbackComposeBackgroundView setViewBackgroundColor:[NSColor whiteColor]];
   [self.messageTextField setBackgroundColor:[NSColor whiteColor]];

--- a/Classes/Feedback/BITFeedbackWindowController.m
+++ b/Classes/Feedback/BITFeedbackWindowController.m
@@ -111,15 +111,20 @@ static NSString * const BITFeedbackMessageDateValueTransformerName = @"BITFeedba
   appIcon = [self imageWithReducedAlpha:0.5 fromImage:appIcon];
   [self.feedbackEmptyAppImageView setImage:appIcon];
   
+  //Hard-coded colors are not compatible with Mojave Dark Mode.
+  /*
   [self.feedbackListBackgroundView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.91 green:0.92 blue:0.93 alpha:1.0]];
   [self.feedbackComposeBackgroundView setViewBackgroundColor:[NSColor whiteColor]];
   [self.horizontalLine setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.79 green:0.82 blue:0.83 alpha:1.0]];
   [self.statusBar setViewBackgroundColor:[NSColor whiteColor]];
   [self.mainBackgroundView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.91 green:0.92 blue:0.93 alpha:1.0]];
   [self.userDataBoxView setViewBackgroundColor:[NSColor colorWithCalibratedRed:0.88 green:0.89 blue:0.90 alpha:1.0]];
-  [self.userDataBoxView setViewBorderWidth:1.0];
   [self.userDataBoxView setViewBorderColor:[NSColor colorWithCalibratedRed:0.82 green:0.85 blue:0.86 alpha:1.0]];
-  
+  */
+  [self.userDataBoxView setViewBorderWidth:1.0];
+  [self.feedbackComposeBackgroundView setViewBackgroundColor:[NSColor whiteColor]];
+  [self.messageTextField setBackgroundColor:[NSColor whiteColor]];
+    
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(tableViewFrameChanged:)
                                                name:NSViewFrameDidChangeNotification


### PR DESCRIPTION
Removed hard-coded colours, because it's not compatible with Mojave Dark Mode.
Before:
![screenshot 2018-10-04 at 16 34 28](https://user-images.githubusercontent.com/40772628/46541015-8e841980-c8c3-11e8-9f0c-4fc5030bf3a3.png)
![screenshot 2018-10-04 at 16 33 45](https://user-images.githubusercontent.com/40772628/46541017-8e841980-c8c3-11e8-8ea5-bf8b4949d1ff.png)
After:
<img width="959" alt="screenshot 2018-10-05 at 17 28 04" src="https://user-images.githubusercontent.com/40772628/46541249-271a9980-c8c4-11e8-832c-f0b2ae6acdf1.png">
<img width="971" alt="screenshot 2018-10-05 at 17 27 46" src="https://user-images.githubusercontent.com/40772628/46541250-271a9980-c8c4-11e8-93aa-c2ea6cd03b72.png">
