### PR TITLE
Fix a critical crash in initWithCXXExceptionInfo

### DIFF
--- a/Classes/CrashReporting/BITCrashManager.m
+++ b/Classes/CrashReporting/BITCrashManager.m
@@ -67,11 +67,11 @@ static PLCrashReporterCallbacks plCrashCallbacks = {
 
 - (instancetype)initWithCXXExceptionInfo:(const BITCrashUncaughtCXXExceptionInfo *)info {
   extern char* __cxa_demangle(const char* mangled_name, char* output_buffer, size_t* length, int* status);
-  char *demangled_name = &__cxa_demangle ? __cxa_demangle(self.info->exception_type_name ?: "", NULL, NULL, NULL) : NULL;
+  char *demangled_name = &__cxa_demangle ? __cxa_demangle(info->exception_type_name ?: "", NULL, NULL, NULL) : NULL;
   
   if ((self = [super
-               initWithName:(NSString *)[NSString stringWithUTF8String:demangled_name ?: self.info->exception_type_name ?: ""]
-               reason:[NSString stringWithUTF8String:self.info->exception_message ?: ""]
+               initWithName:(NSString *)[NSString stringWithUTF8String:demangled_name ?: info->exception_type_name ?: ""]
+               reason:[NSString stringWithUTF8String:info->exception_message ?: ""]
                userInfo:nil])) {
     _info = info;
   }


### PR DESCRIPTION
Fix a critical crash in `[BITCrashCXXExceptionWrapperException initWithCXXExceptionInfo:]`
The problem is that `self` is referenced before initialized.

This is an old bug since 24th July 2017.